### PR TITLE
force utf-16 encoding

### DIFF
--- a/src/fetch_utils.py
+++ b/src/fetch_utils.py
@@ -57,7 +57,7 @@ def fetch_activated_licenses_via_userdata(cookies):
 
 def load_activated_licenses_via_steamctl(fname=STEAMCTL_OUTPUT_FNAME):
     try:
-        with open(fname) as file:
+        with open(fname, encoding='utf-16') as file:
             app_ids = [line.split()[0] for line in file.readlines()]
     except FileNotFoundError:
         app_ids = []


### PR DESCRIPTION
### Fix ValueError: invalid literal for int() with base 10: 'ÿþ5\x00'
```
> python add_free_licenses.py
Traceback (most recent call last):
  File "D:\Programs\Program Portable\Steam Utility\add-free-licenses-main\add_free_licenses.py", line 32, in <module>
    main()
  File "D:\Programs\Program Portable\Steam Utility\add-free-licenses-main\add_free_licenses.py", line 13, in main
    owned_ids = get_owned_ids(
  File "D:\Programs\Program Portable\Steam Utility\add-free-licenses-main\src\get_utils.py", line 30, in get_owned_ids
    owned_ids = load_activated_licenses_via_steamctl()
  File "D:\Programs\Program Portable\Steam Utility\add-free-licenses-main\src\fetch_utils.py", line 65, in load_activated_licenses_via_steamctl
    return to_int(app_ids)
  File "D:\Programs\Program Portable\Steam Utility\add-free-licenses-main\src\utils.py", line 6, in to_int
    return [int(i) for i in ids]
  File "D:\Programs\Program Portable\Steam Utility\add-free-licenses-main\src\utils.py", line 6, in <listcomp>
    return [int(i) for i in ids]
ValueError: invalid literal for int() with base 10: 'ÿþ5\x00'

```
