### PR TITLE
Ignore error for STEAMCTL_OUTPUT_FNAME

### DIFF
--- a/src/fetch_utils.py
+++ b/src/fetch_utils.py
@@ -57,7 +57,7 @@ def fetch_activated_licenses_via_userdata(cookies):
 
 def load_activated_licenses_via_steamctl(fname=STEAMCTL_OUTPUT_FNAME):
     try:
-        with open(fname) as file:
+        with open(fname, errors='ignore') as file:
             app_ids = [line.split()[0] for line in file.readlines()]
     except FileNotFoundError:
         app_ids = []


### PR DESCRIPTION
Fix
ValueError: invalid literal for int() with base 10: 'ÿþ5\x00'

#3 Second way to solve the Value Error